### PR TITLE
feat: allow formatted date cells to be empty

### DIFF
--- a/lib/elixlsx/util.ex
+++ b/lib/elixlsx/util.ex
@@ -231,6 +231,10 @@ defmodule Elixlsx.Util do
     {:formula, value}
   end
 
+  @spec to_excel_datetime(binary() | nil) :: binary()
+  def to_excel_datetime(""), do: ""
+  def to_excel_datetime(nil), do: ""
+
   @doc ~S"""
   Replace_all(input, [{search, replace}]).
 

--- a/test/oracle_test.exs
+++ b/test/oracle_test.exs
@@ -8,9 +8,7 @@ defmodule OracleTest do
 
   defp check(bin) do
     {:ok, package} = @oracle.open(bin, source: :binary)
-    {:ok, sheets} = @oracle.sheets(package)
-
-    dbg(sheets)
+    {:ok, _sheets} = @oracle.sheets(package)
 
     :ok
   end

--- a/test/oracle_test.exs
+++ b/test/oracle_test.exs
@@ -45,7 +45,7 @@ defmodule OracleTest do
     assert check(bin)
   end
 
-  test "empty date celss" do
+  test "empty date cells" do
     s = Sheet.with_name("1") |> Sheet.set_cell("A4", "", yyyymmdd: true)
 
     wk = %Workbook{} |> Workbook.append_sheet(s)

--- a/test/oracle_test.exs
+++ b/test/oracle_test.exs
@@ -8,7 +8,9 @@ defmodule OracleTest do
 
   defp check(bin) do
     {:ok, package} = @oracle.open(bin, source: :binary)
-    {:ok, _sheets} = @oracle.sheets(package)
+    {:ok, sheets} = @oracle.sheets(package)
+
+    dbg(sheets)
 
     :ok
   end
@@ -37,6 +39,16 @@ defmodule OracleTest do
 
   test "date cells" do
     s = Sheet.with_name("1") |> Sheet.set_cell("A4", {{2015, 11, 30}, {21, 20, 38}}, yyyymmdd: true)
+
+    wk = %Workbook{} |> Workbook.append_sheet(s)
+
+    assert {:ok, {_, bin}} = Elixlsx.write_to_memory(wk, "")
+
+    assert check(bin)
+  end
+
+  test "empty date celss" do
+    s = Sheet.with_name("1") |> Sheet.set_cell("A4", "", yyyymmdd: true)
 
     wk = %Workbook{} |> Workbook.append_sheet(s)
 


### PR DESCRIPTION
Allow us to set date format to cells without necessarily passing a date.